### PR TITLE
:sparkles: feat: 디테일 페이지 서버통신 구현

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -98,3 +98,45 @@ export const fetchDetail = async (
       throw new Error('Error', err.message)
     })
 }
+
+export const fetchKakaoShareCount = async (storeId: number) => {
+  return fetch(`/cakestore/share/${storeId}`, { method: 'POST' })
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error('Res.ok Error')
+      }
+      return res.json()
+    })
+    .catch((err) => {
+      console.log(err.message)
+      throw new Error('Error', err.message)
+    })
+}
+
+export const fetchCategorySearch = async (
+  category: string
+): Promise<SearchResponse> => {
+  const data = {
+    addresses: 'null',
+    category: category,
+  }
+  console.log(data)
+  // {"addresses":"[\"송파구\",\"광진구\"]","category":"레터링케이크"}`
+  return fetch(`/cakestore/search`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  })
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error('Res.ok Error')
+      }
+      return res.json()
+    })
+    .catch((err) => {
+      console.log(err.message)
+      throw new Error('Error', err.message)
+    })
+}


### PR DESCRIPTION
1.  라우팅 수정 : 오빠가 만들어준 [detail_id].tsx 사용했습니당!
2. DetailResponseProps랑 내가 PR 보낸거중에 DetailResponse랑 똑같은거 한개로 합쳐주세요 ㅎ... => 오빠걸로 합쳤습니당!! 
3. fetchDetailInfo 랑 내가 올린 fetchDetail이랑 똑같은 거같아 => 이 또한 합쳤습니당!! 


그리고 카카오톡 공유시 조회수 1 늘어나는 거랑 카테고리 누르면 데이터 받아오는 거 추가로 구현해서 pr보냅니당 !! 


+ 현재 서버측에서 카테고리가 중복해서 오는 이슈가 있는데, 희건이가 `Set`으로 해서 보내준대!

<img width="196" alt="스크린샷 2022-05-25 오후 2 58 10" src="https://user-images.githubusercontent.com/72402747/170190418-062e1de9-dc1d-422b-8646-2bbf56924b5f.png">

<img width="388" alt="스크린샷 2022-05-25 오후 2 58 21" src="https://user-images.githubusercontent.com/72402747/170190446-82ecf43c-9f9f-4891-a683-ad7b64371995.png">


