### PR TITLE
Feature/resultpage

### DIFF
--- a/components/detail/shopinfo-container/ShopInfoContainer.tsx
+++ b/components/detail/shopinfo-container/ShopInfoContainer.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react'
+import { useRouter } from 'next/router'
 import styled from '@emotion/styled'
 import { css, jsx } from '@emotion/react'
 import Icon from '../../icon'
@@ -9,6 +10,7 @@ import MoreInfoContainer from '../more/MoreInfoContainer'
 import { categoryList } from '../../../context/CategoryContext'
 import ItemGridContainerStories from '../../item-container/ItemGridContainer.stories'
 import { fetchKakaoShareCount } from '../../../src/api/api'
+import Link from 'next/link'
 
 interface ShopInfoInterface {
   title: string
@@ -32,6 +34,8 @@ const ShopInfoContainer: React.FC<ShopInfoInterface> = ({
   latlng,
   id,
 }) => {
+  const router = useRouter()
+
   const DUMMYTEXT = `### 레터링 케이크 
   - 사이즈 도시락 _ 12cm 1~2인용 19000원~ 
   - 미니 _ 12cm 1~2인용 30000원~ 
@@ -139,15 +143,18 @@ const ShopInfoContainer: React.FC<ShopInfoInterface> = ({
       </h3>
       <div style={{ display: 'flex' }}>
         {categories.map((category: string) => (
-          <Chip
-            primary
+          <Link
             key={category}
-            onClick={() => {
-              console.log('HI')
+            href={{
+              pathname: `/result`,
+              query: { category: getCategory(category) },
             }}
+            passHref
           >
-            #{getCategory(category)}
-          </Chip>
+            <Chip primary key={category}>
+              #{getCategory(category)}
+            </Chip>
+          </Link>
         ))}
       </div>
       <div style={{ display: 'flex', margin: '3rem 0 ' }}>

--- a/pages/result.tsx
+++ b/pages/result.tsx
@@ -3,11 +3,20 @@ import Head from 'next/head'
 import Layout from '../components/layout'
 import React, { useEffect } from 'react'
 import { useRouter } from 'next/router'
+import { fetchSearch } from '../src/api/api'
 
 const Result: NextPage = () => {
   const router = useRouter()
-  console.log(router.query.category)
+  const { category } = router.query
 
+  useEffect(() => {
+    //TODO : 빈배열일 때 에러 해결되었는지 오빠에게 물어보고 코드 수정하기
+    if (typeof category === 'string') {
+      fetchSearch(0, { addresses: [], category: category }).then((res) =>
+        console.log(res)
+      )
+    }
+  }, [])
   return (
     <Layout>
       <Head>
@@ -19,7 +28,7 @@ const Result: NextPage = () => {
         ></script>
       </Head>
       <div>result페이지</div>
-      <div>{router.query.category}</div>
+      <div>{category}</div>
     </Layout>
   )
 }

--- a/pages/result.tsx
+++ b/pages/result.tsx
@@ -1,0 +1,26 @@
+import { GetStaticPaths, GetStaticProps, NextPage } from 'next'
+import Head from 'next/head'
+import Layout from '../components/layout'
+import React, { useEffect } from 'react'
+import { useRouter } from 'next/router'
+
+const Result: NextPage = () => {
+  const router = useRouter()
+  console.log(router.query.category)
+
+  return (
+    <Layout>
+      <Head>
+        <title>케이크크 | 🎂카테고리페이지</title>
+        <link rel="icon" href="/favicon.ico" />
+        <script
+          defer
+          src="https://developers.kakao.com/sdk/js/kakao.min.js"
+        ></script>
+      </Head>
+      <div>result페이지</div>
+      <div>{router.query.category}</div>
+    </Layout>
+  )
+}
+export default Result


### PR DESCRIPTION
1. detail 페이지의 카테고리 Chip을 누르면 해당 카테고리에 맞는 result 페이지로 이동한다
 이때,  `result?category=레터링케이크` 처럼 라우팅된다

2. result 페이지가 마운트될 때 fetchSearch를 통해 카테고리에 해당하는 데이터를 가져온다
<img width="469" alt="스크린샷 2022-05-30 오후 2 37 14" src="https://user-images.githubusercontent.com/72402747/170923952-9efe5f41-923d-4e46-98f8-81fcacd7df89.png">

+ 저번에 빈배열로 보낼 때 오류났다고 했던 거 있잖아! 
result 페이지에서 address는 null로 보내야하는데 저렇게 보내도 되는건가?? 
