### PR TITLE
:bug: fix: getStaticProps with api / useEffect

### DIFF
--- a/pages/detail/[detail_id].tsx
+++ b/pages/detail/[detail_id].tsx
@@ -2,38 +2,64 @@ import { GetServerSideProps, NextPage } from 'next'
 import Head from 'next/head'
 import Layout from '../../components/layout'
 import * as Styled from '../../styles/home'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { ShopInfoContainer } from '../../components/detail/shopinfo-container'
 import { ItemSwiperContainer } from '../../components/item-container'
 import { DetailResponse, fetchDetail } from '../../src/api/api'
+import { useRouter } from 'next/router'
 
-const Detail: NextPage<{ data: DetailResponse[] }> = ({ data }) => {
-  console.log('DaTA!', data)
+const Detail: NextPage = () => {
+  const { query } = useRouter()
+  const [data, setData] = useState<DetailResponse[]>([])
+
+  // console.log(route);
+  useEffect(() => {
+    const fetchDetailData = async () => {
+      try {
+        const fetchedData = await fetchDetail(
+          parseInt(query.detail_id as string)
+        )
+        setData(fetchedData)
+      } catch (err) {
+        console.error('Failed to fetch data in /detail/<detail id>', err)
+      }
+    }
+    // console.log(query.detail_id)
+    if (query.detail_id !== undefined) {
+      fetchDetailData()
+    }
+  }, [query.detail_id])
 
   return (
     <Layout>
       <Head>
-        <title>케이크크 | 🎂{data[0].name}</title>
+        {/* <title>케이크크 | {data ? `🎂${data[0].name}` : 'Loading...'}</title> */}
+        <title>케이크크 | Loading...</title>
         <link rel="icon" href="/favicon.ico" />
         <script
           defer
           src="https://developers.kakao.com/sdk/js/kakao.min.js"
         ></script>
       </Head>
-      <Styled.Home>
-        <ItemSwiperContainer count={3} items={data[0].pictArray} />
-        <ShopInfoContainer
-          id={data[0].id}
-          title={data[0].name}
-          desc={data[0].notice}
-          categories={data[0].storeCategory}
-          tel={data[0].tel}
-          opened={data[0].opened}
-          closed={data[0].closed}
-          url={data[0].url}
-          latlng={data[0].latlng}
-        />
-      </Styled.Home>
+      <div></div>
+      {data.length !== 0 ? (
+        <Styled.Home>
+          <ItemSwiperContainer count={3} items={data[0].pictArray} />
+          <ShopInfoContainer
+            id={data[0].id}
+            title={data[0].name}
+            desc={data[0].notice}
+            categories={data[0].storeCategory}
+            tel={data[0].tel}
+            opened={data[0].opened}
+            closed={data[0].closed}
+            url={data[0].url}
+            latlng={data[0].latlng}
+          />
+        </Styled.Home>
+      ) : (
+        <div>Loading</div>
+      )}
     </Layout>
   )
 }
@@ -45,19 +71,19 @@ const Detail: NextPage<{ data: DetailResponse[] }> = ({ data }) => {
 //   }
 // }
 
-export const getServerSideProps: GetServerSideProps = async ({ params }) => {
-  // Fetch Detail before render
-  const data = await fetchDetail(parseInt(params?.detail_id as string))
+// export const getServerSideProps: GetServerSideProps = async ({ params }) => {
+//   // Fetch Detail before render
+//   let data = [] as DetailResponse[]
 
-  if (!data) {
-    return {
-      notFound: true,
-    }
-  }
+//   try {
+//     data = await fetchDetail(parseInt(params?.detail_id as string))
+//   } catch (err) {
+//     console.error('Failed to fetch data in /detail/<detail id>', err)
+//   }
 
-  return {
-    props: { data }, // will be passed to the page component as props
-  }
-}
+//   return {
+//     props: { data }, // will be passed to the page component as props
+//   }
+// }
 
 export default Detail

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,4 @@
-import type { GetServerSideProps } from 'next'
+import type { GetServerSideProps, GetStaticProps } from 'next'
 import Head from 'next/head'
 import BannerContainer from '../components/main/banner'
 import Layout from '../components/layout'
@@ -11,6 +11,7 @@ import { CategoryProvider, LocationProvider } from '../context'
 import { fetchPopular, ItemResponseProps } from '../src/api/api'
 
 const Home = ({ data }: { data: ItemResponseProps[] }) => {
+  console.log('👻', data)
   return (
     <Layout>
       <Head>
@@ -24,7 +25,7 @@ const Home = ({ data }: { data: ItemResponseProps[] }) => {
             <BannerContainer />
             <SeacrhContainer />
             <RankContainer data={data} />
-            <AreaContainer />
+            {/* <AreaContainer /> */}
           </CategoryProvider>
         </LocationProvider>
       </Styled.Home>
@@ -32,11 +33,15 @@ const Home = ({ data }: { data: ItemResponseProps[] }) => {
   )
 }
 
-export const getServerSideProps: GetServerSideProps = async () => {
-  const data = await fetchPopular()
-
-  return {
-    props: { data }, // will be passed to the page component as props
+export const getStaticProps: GetStaticProps = async () => {
+  try {
+    const data = await fetchPopular()
+    return {
+      props: { data }, // will be passed to the page component as props
+    }
+  } catch (err) {
+    console.error('Failed to fetch data in /', err)
+    return { props: { data: [] } }
   }
 }
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,4 +1,4 @@
-// const API_ENDPOINT = 'http://15.165.196.34:8000'
+const OUT_API_ENDPOINT = 'http://15.165.196.34:8000'
 const API_ENDPOINT = 'http://localhost:3000/api'
 
 //TODO: picture => picurl
@@ -49,7 +49,7 @@ export type MapResponse = {
 }
 
 export const fetchPopular = async (): Promise<ItemResponseProps[]> => {
-  return fetch(`${API_ENDPOINT}/cakestore/popular`)
+  return fetch(`${OUT_API_ENDPOINT}/cakestore/popular`)
     .then((res) => {
       if (!res.ok) {
         throw new Error('Res.ok Error')


### PR DESCRIPTION
## 빌드시 고려해야 하는 getStaticProps / getServerSideProps

- `getStaticProps` 는 빌드를 할때 api를 불러올 수 있긴하지만 **외부 API** 가 아니면 에러가 뜬다는거 
- `getServerSideProps`는 빌드를 할때 오류는 안나지만... 500 Internal Server error 가 뜨는데 이거는 솔직히 해결책을 못찾았어...

첫번째 `getStaticProsp`는 잘 풀려서 다행이긴 하지만.. 밑에 있는 것을 `useEffect`로 바꾸고 `getStaticProps`를 안썼어


## `getServerSideProps`의 해결책
useEffect를 이용하여 즉각즉각 fetch 한다

장점
✔️ React가 사용하는 방식이니 더 익숙하다
✔️ Loading Page를 사용할 수 있다

단점
✔️ 이럴 거면 Next.js 왜 써.
✔️ 동적라우팅을 쓰기 때문에 `getStaticPaths`를 써야하는데 그 안에 미리 paths를 적어놔야한다. 

