### PR TITLE
bug: fix: result api page fixed

### DIFF
--- a/components/main/area-section/AreaContainer.tsx
+++ b/components/main/area-section/AreaContainer.tsx
@@ -65,18 +65,21 @@ const AreaContainer: React.FC = () => {
 
   // Fetch API
   useEffect(() => {
-    const categoryTitle = categoryList.find(
-      (category: CategoryInterface) => category.name === categoryState.category
-    )?.title
+    // const categoryTitle = categoryList.find(
+    //   (category: CategoryInterface) => category.name === categoryState.category
+    // )?.title
 
-    fetchSearch(page, {
-      addresses: locationState.location,
-      category: categoryTitle ? categoryTitle : 'null',
-    }).then((res) => {
-      // setPage(res.page)
-      setTotalPage(res.totalpage)
-      setItems(res.data)
-    })
+    if (categoryState.category !== '') {
+      fetchSearch(page, {
+        addresses: locationState.location,
+        category: categoryState.category,
+      }).then((res) => {
+        console.log('result', res)
+        setPage(res.page)
+        setTotalPage(res.totalpage)
+        setItems(res.data)
+      })
+    }
   }, [page, categoryState, locationState])
 
   return (

--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,9 @@ module.exports = {
       'modo-phinf.pstatic.net',
       'search.pstatic.net',
       'ldb-phinf.pstatic.net',
+      'postfiles.pstatic.net',
+      'k.kakaocdn.net',
+      'mblogthumb-phinf.pstatic.net',
     ], // 이곳에 에러에서 hostname 다음 따옴표에 오는 링크를 적으면 된다.
   },
   async rewrites() {

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -70,10 +70,11 @@ export const fetchSearch = async (
   }
 ): Promise<SearchResponse> => {
   const data = {
-    addresses:
-      body.addresses.length > 0 ? JSON.stringify(body.addresses) : '["null"]',
+    addresses: body.addresses,
     category: body.category,
   }
+
+  console.log('fetchSearch', data)
 
   // {"addresses":"[\"송파구\",\"광진구\"]","category":"레터링케이크"}`
   return fetch(`${API_ENDPOINT}/cakestore/search?page=${page}`, {


### PR DESCRIPTION
## ⚠️ 이건 시간날 때 한번 봐줘

`api.ts`랑 `result.tsx` 관련된 거 인데.

`fetchSearch`가 이제 정상 작동되고 프리캐싱하는 이미지 url 업데이트 한거야

기존에 fetchSearch에 보냈던 정보가
```
{
  "addresses": "[\"null\"]",
  "category": "null"
}
```
에서 
```
{
  "addresses": [],
  "category": ""
}
```
으로 바뀌었어. 

심심할때 한번 확인해주고,
category 설정 안하면 너무 휑한 느낌이라서 한번 고민 해봐야 할거같아.

<img width="1150" alt="스크린샷 2022-07-04 오후 4 57 48" src="https://user-images.githubusercontent.com/50029346/177109116-e66dc79b-f67c-43ac-8065-1fbefb7fda97.png">

우선 급한대로 머지는 시킬께!

그래도 한번 리뷰는 해줘

